### PR TITLE
Word wrap & Gulp task fix

### DIFF
--- a/build/tasks/pre-install.js
+++ b/build/tasks/pre-install.js
@@ -1,5 +1,5 @@
 module.exports = function(gulp, options, plugins) {
     gulp.task('pre-install', function(){
-        return plugins.fs.mkdir(options.installFolder);
+        return plugins.fs.mkdirSync(options.installFolder);
     });
 };

--- a/src/extension/publish/instances/TextInstance.js
+++ b/src/extension/publish/instances/TextInstance.js
@@ -90,6 +90,11 @@ p.renderContent = function(renderer, undefined)
     if (style.letterSpacing)
         options.letterSpacing = style.letterSpacing;
 
+    if(this.libraryItem.behaviour.lineMode === 'multi'){
+        options.wordWrap = true;
+        options.wordWrapWidth = this.initFrame.bounds.width;
+    }
+
     // Replace the long names with the shortened names
     if (compress)
     {

--- a/src/extension/publish/instances/TextInstance.js
+++ b/src/extension/publish/instances/TextInstance.js
@@ -90,7 +90,8 @@ p.renderContent = function(renderer, undefined)
     if (style.letterSpacing)
         options.letterSpacing = style.letterSpacing;
 
-    if (this.libraryItem.behaviour.lineMode === 'multi'){
+    if (this.libraryItem.behaviour.lineMode === 'multi')
+    {
         options.wordWrap = true;
         options.wordWrapWidth = this.initFrame.bounds.width;
     }

--- a/src/extension/publish/instances/TextInstance.js
+++ b/src/extension/publish/instances/TextInstance.js
@@ -90,7 +90,7 @@ p.renderContent = function(renderer, undefined)
     if (style.letterSpacing)
         options.letterSpacing = style.letterSpacing;
 
-    if(this.libraryItem.behaviour.lineMode === 'multi'){
+    if (this.libraryItem.behaviour.lineMode === 'multi'){
         options.wordWrap = true;
         options.wordWrapWidth = this.initFrame.bounds.width;
     }


### PR DESCRIPTION
- Enables automatic word-wrap option for multiline text fields.
- Fixes gulp task compatibility with node 10.

Note: Word wrap feature assumes that the width of a given text instance does not change over the course of a timeline.