### PR TITLE
Fix use of Graphic symbols in Animate 2019+

### DIFF
--- a/project/mac/lib/debug/PixiAnimate.fcm.plugin/Contents/Resources/include/IOutputWriter.h
+++ b/project/mac/lib/debug/PixiAnimate.fcm.plugin/Contents/Resources/include/IOutputWriter.h
@@ -276,7 +276,8 @@ namespace PixiJS
 			const DOM::Utils::MATRIX2D* pMatrix,
 			bool loop,
 			std::string instanceName,
-			FCM::PIFCMUnknown pUnknown) = 0;
+			FCM::PIFCMUnknown pUnknown,
+			bool isGraphic) = 0;
 
 		virtual FCM::Result PlaceObject(
 			FCM::U_Int32 resId,

--- a/project/mac/lib/debug/PixiAnimate.fcm.plugin/Contents/Resources/include/TimelineWriter.h
+++ b/project/mac/lib/debug/PixiAnimate.fcm.plugin/Contents/Resources/include/TimelineWriter.h
@@ -35,7 +35,8 @@ namespace PixiJS
 			const DOM::Utils::MATRIX2D* pMatrix,
 			bool loop,
 			std::string instanceName,
-			FCM::PIFCMUnknown pUnknown);
+			FCM::PIFCMUnknown pUnknown,
+			bool isGraphic);
 
 		virtual FCM::Result PlaceObject(
 			FCM::U_Int32 resId,

--- a/src/PixiAnimate/include/IOutputWriter.h
+++ b/src/PixiAnimate/include/IOutputWriter.h
@@ -276,7 +276,8 @@ namespace PixiJS
 			const DOM::Utils::MATRIX2D* pMatrix,
 			bool loop,
 			std::string instanceName,
-			FCM::PIFCMUnknown pUnknown) = 0;
+			FCM::PIFCMUnknown pUnknown,
+			bool isGraphic) = 0;
 
 		virtual FCM::Result PlaceObject(
 			FCM::U_Int32 resId,

--- a/src/PixiAnimate/include/TimelineWriter.h
+++ b/src/PixiAnimate/include/TimelineWriter.h
@@ -35,7 +35,8 @@ namespace PixiJS
 			const DOM::Utils::MATRIX2D* pMatrix,
 			bool loop,
 			std::string instanceName,
-			FCM::PIFCMUnknown pUnknown);
+			FCM::PIFCMUnknown pUnknown,
+			bool isGraphic);
 
 		virtual FCM::Result PlaceObject(
 			FCM::U_Int32 resId,

--- a/src/PixiAnimate/src/Publisher.cpp
+++ b/src/PixiAnimate/src/Publisher.cpp
@@ -1925,7 +1925,8 @@ namespace PixiJS
 			&pMovieClipInfo->matrix,
 			true,
 			instanceName,
-			pUnknown);
+			pUnknown,
+			false);
 
 		return res;
 	}
@@ -1947,7 +1948,8 @@ namespace PixiJS
 			&pGraphicInfo->matrix,
 			false,
 			"",
-			NULL);
+			NULL,
+			true);
 
 		return res;
 	}

--- a/src/PixiAnimate/src/TimelineWriter.cpp
+++ b/src/PixiAnimate/src/TimelineWriter.cpp
@@ -62,7 +62,8 @@ namespace PixiJS
 		const DOM::Utils::MATRIX2D* pMatrix,
 		bool loop,
 		std::string instanceName,
-		FCM::PIFCMUnknown pUnknown)
+		FCM::PIFCMUnknown pUnknown,
+		bool isGraphic)
 	{
 		JSONNode commandElement(JSON_NODE);
 
@@ -82,6 +83,7 @@ namespace PixiJS
 		}
 
 		commandElement.push_back(JSONNode("loop", (bool)loop));
+		commandElement.push_back(JSONNode("isGraphic", (bool)isGraphic));
 		m_pCommandArray->push_back(commandElement);
 
 		return FCM_SUCCESS;

--- a/src/extension/publish/Library.js
+++ b/src/extension/publish/Library.js
@@ -114,13 +114,23 @@ const Library = function(data)
     });
 
     let self = this;
+    let timelineNames = data.Timelines.map(timelineData => timelineData.name);
+    let graphics = 0;
     for(let timelineData of data.Timelines){
         if(timelineData.frames && timelineData.frames.length){
             for(let frame of timelineData.frames){
                 if(frame.commands && frame.commands.length){
                     for(let command of frame.commands){
                         if(command.type === 'Place' && command.isGraphic){
-                            data.Timelines.find(data => data.assetId === command.assetId).type = 'graphic';
+                            let asset = data.Timelines.find(data => data.assetId === command.assetId);
+                            if(asset.type !== 'graphic'){
+                                asset.type = 'graphic';
+                                let name = `Graphic${++graphics}`;
+                                while(timelineNames.includes(name)){
+                                    name = `Graphic${++graphics}`;
+                                }
+                                asset.name = name;
+                            }
                         }
                     }
                 }

--- a/src/extension/publish/Library.js
+++ b/src/extension/publish/Library.js
@@ -114,6 +114,19 @@ const Library = function(data)
     });
 
     let self = this;
+    for(let timelineData of data.Timelines){
+        if(timelineData.frames && timelineData.frames.length){
+            for(let frame of timelineData.frames){
+                if(frame.commands && frame.commands.length){
+                    for(let command of frame.commands){
+                        if(command.type === 'Place' && command.isGraphic){
+                            data.Timelines.find(data => data.assetId === command.assetId).type = 'graphic';
+                        }
+                    }
+                }
+            }
+        }
+    }
     data.Timelines.forEach(function(timelineData)
     {
         let timeline;


### PR DESCRIPTION
This extension has been relying on the symbol name of a Graphic instance being `null` to differentiate Graphics from MovieClips. In Animate 2019 and later, Graphic instances do not have a null symbol name. This change records whether or not a placed symbol is used Graphic, and corrects the symbol's type definition and naming convention in the final output.