### PR TITLE
guard against quote characters in text strings

### DIFF
--- a/src/extension/publish/instances/TextInstance.js
+++ b/src/extension/publish/instances/TextInstance.js
@@ -114,7 +114,7 @@ p.renderContent = function(renderer, undefined)
     }
 
     let buffer = renderer.template('text-instance', {
-        text: this.libraryItem.txt || ""
+        text: (this.libraryItem.txt || "").replace(/"/g, "\\\"")
     });
 
     // Add the style setter


### PR DESCRIPTION
Just noticed that quote characters `"` weren't getting escaped in the final output